### PR TITLE
add missing return column "type" to the concordia purchases endpoint

### DIFF
--- a/admin-api-server/src/analytics/controller/analytics.controller.ts
+++ b/admin-api-server/src/analytics/controller/analytics.controller.ts
@@ -370,7 +370,8 @@ export class AnalyticsController {
    *
    *    [
    *        {
-   *            "index": 1,
+   *            "transaction_id": 1,
+   *            "type": "sale",
    *            "wallet_address": "tz2JjcM2wo1GC3DxV8ra2Kb95Upswj39ueCa",
    *            "marketing_consent": false,
    *            "age_verification": true,
@@ -391,7 +392,8 @@ export class AnalyticsController {
    *            "purchaser_country": "GB",
    *        },
    *        {
-   *            "index": 2
+   *            "transaction_id": 2
+   *            "type": "sale,
    *            "wallet_address": "tz2JjcM2wo1GC3DxV8ra2Kb95Upswj39ueCc",
    *            "marketing_consent": true,
    *            "age_verification": true,

--- a/admin-api-server/src/analytics/entity/analytics.entity.ts
+++ b/admin-api-server/src/analytics/entity/analytics.entity.ts
@@ -43,7 +43,8 @@ export interface Activity {
 }
 
 export interface Purchase {
-  index: number;
+  transaction_id: number;
+  type: string;
 
   wallet_address: string;
   email?: string;

--- a/admin-api-server/src/analytics/service/analytics.service.ts
+++ b/admin-api-server/src/analytics/service/analytics.service.ts
@@ -589,7 +589,8 @@ ORDER BY index
         );
 
         return {
-          index: Number(row['index']),
+          transaction_id: Number(row['index']),
+          type: 'sale',
 
           wallet_address: row['address'],
           email: row['email'] != null ? row['email'] : undefined,


### PR DESCRIPTION
This `type` field was requested a while ago to be included in the custom purchases analytics endpoint. At the moment we only report sales events, so this field is simply hardcoded to 'sale' for now

Also changed the `index` field in this API endpoint response to be called `transaction_id` (this was requested as well)